### PR TITLE
BF Making npm test command exit by default by turning watch off

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,8 @@
               "src/styles.css",
               "node_modules/bootstrap/dist/css/bootstrap.min.css"
             ],
-            "scripts": ["node_modules/jquery/dist/jquery.min.js",
+            "scripts": [
+              "node_modules/jquery/dist/jquery.min.js",
               "node_modules/bootstrap/dist/js/bootstrap.min.js"
             ]
           },
@@ -122,6 +123,10 @@
           }
         }
       }
-    }},
-  "defaultProject": "test-for-real-for-real"
+    }
+  },
+  "defaultProject": "test-for-real-for-real",
+  "cli": {
+    "analytics": "d9546dc7-84f8-4842-af2b-4c6a15b75814"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "node server.js",
     "build": "ng build",
-    "test": "ng test",
+    "test": "ng test --watch=false",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },


### PR DESCRIPTION
Resolves #8 with a change to package.json

Tests will now exit automatically when `npm run test` is run